### PR TITLE
Fix make upgrade issue and ran make upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.4.1
+asgiref==3.5.0
     # via django
 django==3.2.11
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,7 +8,7 @@ certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.10
     # via requests
-coverage==6.2
+coverage==6.3
     # via coveralls
 coveralls==3.3.1
     # via -r requirements/ci.in
@@ -41,7 +41,7 @@ py==1.11.0
     # via
     #   -r requirements/tox.txt
     #   tox
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -r requirements/tox.txt
     #   packaging

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,3 @@
 
 # This file contains all common constraints for edx-repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# zipp 2.0.0 requires Python >= 3.6
-zipp<2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ alabaster==0.7.12
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-asgiref==3.4.1
+asgiref==3.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -52,7 +52,7 @@ code-annotations==1.2.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==6.2
+coverage[toml]==6.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -96,6 +96,11 @@ idna==3.3
     #   -r requirements/test.txt
     #   requests
 imagesize==1.3.0
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   sphinx
+importlib-metadata==4.10.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -187,7 +192,7 @@ pylint-plugin-utils==0.7
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -239,7 +244,7 @@ snowballstemmer==2.2.0
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-sphinx==4.3.2
+sphinx==4.4.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -319,6 +324,11 @@ wrapt==1.13.3
     # via
     #   -r requirements/test.txt
     #   astroid
+zipp==3.7.0
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -20,6 +20,8 @@ idna==3.3
     # via requests
 imagesize==1.3.0
     # via sphinx
+importlib-metadata==4.10.1
+    # via sphinx
 jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
@@ -30,7 +32,7 @@ pockets==0.9.1
     # via sphinxcontrib-napoleon
 pygments==2.11.2
     # via sphinx
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 pytz==2021.3
     # via babel
@@ -42,7 +44,7 @@ six==1.16.0
     #   sphinxcontrib-napoleon
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.3.2
+sphinx==4.4.0
     # via
     #   -r requirements/docs.in
     #   sphinx-rtd-theme
@@ -64,6 +66,5 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 urllib3==1.26.8
     # via requests
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+zipp==3.7.0
+    # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via
     #   -r requirements/docs.txt
     #   sphinx
-asgiref==3.4.1
+asgiref==3.5.0
     # via
     #   -r requirements/base.txt
     #   django
@@ -39,7 +39,7 @@ click-log==0.3.2
     # via edx-lint
 code-annotations==1.2.0
     # via edx-lint
-coverage[toml]==6.2
+coverage[toml]==6.3
     # via pytest-cov
 ddt==1.4.4
     # via -r requirements/test.in
@@ -70,6 +70,10 @@ idna==3.3
     #   -r requirements/docs.txt
     #   requests
 imagesize==1.3.0
+    # via
+    #   -r requirements/docs.txt
+    #   sphinx
+importlib-metadata==4.10.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -133,7 +137,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -r requirements/docs.txt
     #   packaging
@@ -175,7 +179,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sphinx==4.3.2
+sphinx==4.4.0
     # via
     #   -r requirements/docs.txt
     #   sphinx-rtd-theme
@@ -233,6 +237,10 @@ urllib3==1.26.8
     #   requests
 wrapt==1.13.3
     # via astroid
+zipp==3.7.0
+    # via
+    #   -r requirements/docs.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -18,7 +18,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 six==1.16.0
     # via


### PR DESCRIPTION
`Zip` was constrained to <2.0.0 due to python36 but we have already dropped support for python36 and this pin was causing version mismatches in the requirement files so unpinned it and ran make upgrade