### PR TITLE
fix: bug in get_team_ids_by_team_submission_uuid

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.5.0'
+__version__ = '3.5.1'

--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -350,7 +350,7 @@ def get_team_ids_by_team_submission_uuid(team_submission_uuids):
     team submission uuids to team id
     """
     values = TeamSubmission.objects.filter(
-        team_submission_uuid__in=team_submission_uuids
+        uuid__in=team_submission_uuids
     ).values(
         "uuid", "team_id"
     )

--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -355,7 +355,7 @@ def get_team_ids_by_team_submission_uuid(team_submission_uuids):
         "uuid", "team_id"
     )
     return {
-        item['uuid']: item['team_id']
+        str(item['uuid']): item['team_id']
         for item in values
     }
 


### PR DESCRIPTION
**TL;DR** fix lookup in `get_team_ids_by_team_submission_uuid`

As part of ESG team support ticket ([AU-493](https://openedx.atlassian.net/browse/AU-493)) I ran into this bug. The delicious irony: we have an outstanding ticket to write tests ([AU-343](https://openedx.atlassian.net/browse/AU-343)) which would have caught this.

**NOTE** writing tests is going to wait until AU-343 for expediency.