### PR TITLE
fix: manually update pip-tools version to 6.5.1 to fix pip/pip-tools bug

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/pip-tools.in
 tomli==2.0.0
     # via pep517


### PR DESCRIPTION
The following comment is borrowed from this pull request, with changes: https://github.com/openedx/opaque-keys/pull/218.

This failure started happening in the [automated requirements upgrade GitHub action](https://github.com/openedx/edx-submissions/runs/5704384647?check_suite_focus=true).

The bug was being caused by an interaction between pip and pip-tools, described here: https://github.com/jazzband/pip-tools/issues/1558

The bug is fixed in pip-tools==6.5.0 - from this PR: https://github.com/jazzband/pip-tools/pull/1567

This pull requests bumps the version of pip-tools manually to get the automated upgrades working again.