### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ upgrade: ## Update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade --verbose --rebuild -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade --verbose --rebuild -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade --verbose --rebuild -o requirements/docs.txt requirements/docs.in
 	pip-compile --upgrade --verbose --rebuild -o requirements/test.txt requirements/test.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
 django==3.2.13
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 charset-normalizer==2.0.12
     # via requests
-coverage==6.3.2
+coverage==6.4.1
     # via coveralls
 coveralls==3.3.1
     # via -r requirements/ci.in
@@ -18,7 +18,7 @@ distlib==0.3.4
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.6.0
+filelock==3.7.1
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -41,7 +41,7 @@ py==1.11.0
     # via
     #   -r requirements/tox.txt
     #   tox
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   -r requirements/tox.txt
     #   packaging

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,12 +9,12 @@ alabaster==0.7.12
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.11.3
+astroid==2.11.5
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -28,7 +28,7 @@ babel==2.10.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -38,7 +38,7 @@ charset-normalizer==2.0.12
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-click==8.1.2
+click==8.1.3
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -52,13 +52,13 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==6.3.2
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/test.txt
-dill==0.3.4
+dill==0.3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -88,7 +88,7 @@ edx-lint==5.2.2
     # via -r requirements/test.txt
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==13.4.0
+faker==13.12.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -104,7 +104,7 @@ imagesize==1.3.0
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -117,7 +117,7 @@ isort==5.10.1
     # via
     #   -r requirements/test.txt
     #   pylint
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -148,7 +148,7 @@ packaging==21.3
     #   -r requirements/test.txt
     #   pytest
     #   sphinx
-pbr==5.8.1
+pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -176,7 +176,7 @@ pygments==2.12.0
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-pylint==2.13.7
+pylint==2.14.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -196,7 +196,7 @@ pylint-plugin-utils==0.7
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -215,7 +215,7 @@ python-dateutil==2.8.2
     #   -r requirements/test.txt
     #   faker
     #   freezegun
-python-slugify==6.1.1
+python-slugify==6.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -248,7 +248,7 @@ snowballstemmer==2.2.0
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-sphinx==4.5.0
+sphinx==5.0.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -310,6 +310,10 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
+tomlkit==0.11.0
+    # via
+    #   -r requirements/test.txt
+    #   pylint
 typing-extensions==4.2.0
     # via
     #   -r requirements/test.txt
@@ -320,7 +324,7 @@ urllib3==1.26.9
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-wrapt==1.14.0
+wrapt==1.14.1
     # via
     #   -r requirements/test.txt
     #   astroid

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.10.1
     # via sphinx
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 charset-normalizer==2.0.12
     # via requests
@@ -20,9 +20,9 @@ idna==3.3
     # via requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via sphinx
-jinja2==3.1.1
+jinja2==3.1.2
     # via sphinx
 markupsafe==2.1.1
     # via jinja2
@@ -32,7 +32,7 @@ pockets==0.9.1
     # via sphinxcontrib-napoleon
 pygments==2.12.0
     # via sphinx
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
 pytz==2022.1
     # via babel
@@ -44,7 +44,7 @@ six==1.16.0
     #   sphinxcontrib-napoleon
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.5.0
+sphinx==5.0.1
     # via
     #   -r requirements/docs.in
     #   sphinx-rtd-theme

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-click==8.1.2
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.4
+pip==22.1.2
     # via -r requirements/pip.in
-setuptools==62.1.0
+setuptools==62.3.2
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,11 +8,11 @@ alabaster==0.7.12
     # via
     #   -r requirements/docs.txt
     #   sphinx
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.11.3
+astroid==2.11.5
     # via
     #   pylint
     #   pylint-celery
@@ -22,7 +22,7 @@ babel==2.10.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/docs.txt
     #   requests
@@ -30,7 +30,7 @@ charset-normalizer==2.0.12
     # via
     #   -r requirements/docs.txt
     #   requests
-click==8.1.2
+click==8.1.3
     # via
     #   click-log
     #   code-annotations
@@ -39,11 +39,11 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==6.3.2
+coverage[toml]==6.4.1
     # via pytest-cov
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/test.in
-dill==0.3.4
+dill==0.3.5.1
     # via pylint
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -63,7 +63,7 @@ edx-lint==5.2.2
     # via -r requirements/test.in
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==13.4.0
+faker==13.12.1
     # via factory-boy
 freezegun==1.2.1
     # via -r requirements/test.in
@@ -75,7 +75,7 @@ imagesize==1.3.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -85,7 +85,7 @@ isort==5.10.1
     # via
     #   -r requirements/test.in
     #   pylint
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   -r requirements/docs.txt
     #   code-annotations
@@ -107,7 +107,7 @@ packaging==21.3
     #   -r requirements/docs.txt
     #   pytest
     #   sphinx
-pbr==5.8.1
+pbr==5.9.0
     # via stevedore
 platformdirs==2.5.2
     # via pylint
@@ -125,7 +125,7 @@ pygments==2.12.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-pylint==2.13.7
+pylint==2.14.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -139,7 +139,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   -r requirements/docs.txt
     #   packaging
@@ -156,7 +156,7 @@ python-dateutil==2.8.2
     #   -r requirements/test.in
     #   faker
     #   freezegun
-python-slugify==6.1.1
+python-slugify==6.1.2
     # via code-annotations
 pytz==2022.1
     # via
@@ -181,7 +181,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sphinx==4.5.0
+sphinx==5.0.1
     # via
     #   -r requirements/docs.txt
     #   sphinx-rtd-theme
@@ -226,6 +226,8 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
+tomlkit==0.11.0
+    # via pylint
 typing-extensions==4.2.0
     # via
     #   astroid
@@ -234,7 +236,7 @@ urllib3==1.26.9
     # via
     #   -r requirements/docs.txt
     #   requests
-wrapt==1.14.0
+wrapt==1.14.1
     # via astroid
 zipp==3.8.0
     # via

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,7 +6,7 @@
 #
 distlib==0.3.4
     # via virtualenv
-filelock==3.6.0
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
@@ -18,7 +18,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
 six==1.16.0
     # via


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3447