### PR TITLE
fix: race condition for team ORA

### DIFF
--- a/submissions/api.py
+++ b/submissions/api.py
@@ -988,7 +988,21 @@ def _get_or_create_student_item(student_item_dict):
                     }
                 )
                 raise SubmissionRequestError(field_errors=student_item_serializer.errors) from student_error
-            return student_item_serializer.save()
+            try:
+                # This is required because we currently have automatic request transactions turned on in the LMS.
+                # Database errors mess up the "atomic" block so we have to "insulate" against them with an
+                # inner atomic block
+                with transaction.atomic():
+                    return student_item_serializer.save()
+            except IntegrityError:
+                # In the case where a student item does not exist and multiple calls to this function happen, there
+                # can be a race condition where the first get has no results, but once the save happens there is already
+                # a version of this student item. In that case, try just loading again and see if the item exists now.
+                try:
+                    return StudentItem.objects.get(**student_item_dict)
+                except StudentItem.DoesNotExist:
+                     pass
+                raise
     except DatabaseError as error:
         error_message = f"An error occurred creating student item: {student_item_dict}"
         logger.exception(error_message)


### PR DESCRIPTION
**TL;DR**: "resolve" a race condition caused by team ORAs

**What's the bug?**:

- When we load an ORA, we make a separate web request to render each ORA "section". Each of these requests need to know the team submission uuid, if there is one, so they all make calls to the submissions api.
- The submissions api looks up student items in the following way:
        1) Check if the item exists
        2) If it doesn't, create a serializer and validate that the fields are valid
        3) Save the serializer to the database
- All these calls would get past (1) with no created item, and one fast request would save the item and succeed. All others would try to save the item and fail with an IntegrityeError because there is now an item.

**What's the fix?**:

- If we're getting an IntegrityError, it means that the thing we wanted now exists. Just return the thing that now exists!
- The tricky bit here is that we are in an atomic block, and database errors raised in an atomic block "poison" the rest of the atomic block and prevent us from making further queries. We must "insulate" the atomic block with another, messy but necessary, atomic block.
