### PR TITLE
Jkantor/ensure ascii

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.5.2'
+__version__ = '3.5.3'

--- a/submissions/models.py
+++ b/submissions/models.py
@@ -319,7 +319,7 @@ class Submission(models.Model):
     # replacement for TextField that performs JSON serialization/deserialization.
     # For backwards compatibility, we override the default database column
     # name so it continues to use `raw_answer`.
-    answer = JSONField(blank=True, db_column="raw_answer")
+    answer = JSONField(blank=True, dump_kwargs={'ensure_ascii': True}, db_column="raw_answer")
 
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=ACTIVE)
 


### PR DESCRIPTION
This fixes a bug where we are unable to store 4-byte UTF-8 unicode characters due to the encoding on this table. Rather than rebuilding the entire table with a different encoding, we thought the more straightforward fix was to simply json-encode characters before saving in the DB

I've tested this locally but I will be monitoring this release and will be testing on stage before the prod rollout. It does seem to work cleanly on devstack, so fingers crossed everything is nice