### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,3 @@
-Part of `edX code`__.
-
-__ http://code.edx.org/
-
 .. image:: https://github.com/openedx/edx-submissions/workflows/Python%20CI/badge.svg?branch=master
     :target: https://github.com/openedx/edx-submissions/actions?query=workflow%3A%22Python+CI%22
     :alt: Build status
@@ -65,10 +61,7 @@ How To Contribute
 
 Contributions are very welcome.
 
-Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
-
-Even though it was written with ``edx-platform`` in mind, the guidelines
-should be followed for Open edX code in general.
+Please read `How To Contribute <https://github.com/openedx/.github/blob/master/CONTRIBUTING.md>`_ for details.
 
 
 Reporting Security Issues


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
