### PR TITLE
Upgrading drf to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         os: [ubuntu-20.04]
         python-version: ['3.8']
         toxenv: [
-            quality, docs, django32-drf312, django32-drf314, django32-drflatest,
-            django40-drf312, django40-drf314, django40-drflatest
+            quality, docs, django32-drf312, django32-drf314,
+            django40-drf312, django40-drf314
         ]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.8']
-        toxenv: [quality, docs, django32-drf312, django32-drflatest, django40-drf312, django40-drflatest]
+        toxenv: [
+            quality, docs, django32-drf312, django32-drf314, django32-drflatest,
+            django40-drf312, django40-drf314, django40-drflatest
+        ]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,5 +10,5 @@ pytz
 
 
 # Don't let edx-platform upgrade DRF past versions that have already been tested here
-djangorestframework<3.13.0
+djangorestframework<3.15.0
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-django==3.2.18
+django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -15,7 +15,7 @@ django==3.2.18
     #   jsonfield
 django-model-utils==4.3.1
     # via -r requirements/base.in
-djangorestframework==3.12.4
+djangorestframework==3.14.0
     # via -r requirements/base.in
 jsonfield==3.1.0
     # via -r requirements/base.in
@@ -23,5 +23,8 @@ pytz==2023.3
     # via
     #   -r requirements/base.in
     #   django
-sqlparse==0.4.3
+    #   djangorestframework
+sqlparse==0.4.4
     # via django
+typing-extensions==4.6.3
+    # via asgiref

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
@@ -18,7 +18,7 @@ distlib==0.3.6
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.11.0
+filelock==3.12.2
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -29,7 +29,7 @@ packaging==23.1
     # via
     #   -r requirements/tox.txt
     #   tox
-platformdirs==3.2.0
+platformdirs==3.5.3
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -41,7 +41,7 @@ py==1.11.0
     # via
     #   -r requirements/tox.txt
     #   tox
-requests==2.28.2
+requests==2.31.0
     # via coveralls
 six==1.16.0
     # via
@@ -55,9 +55,9 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/tox.txt
-urllib3==1.26.15
+urllib3==2.0.3
     # via requests
-virtualenv==20.21.0
+virtualenv==20.23.0
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,12 +9,12 @@ alabaster==0.7.13
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.15.2
+astroid==2.15.5
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -24,7 +24,7 @@ babel==2.12.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -48,7 +48,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.2.3
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -58,7 +58,7 @@ dill==0.3.6
     # via
     #   -r requirements/test.txt
     #   pylint
-django==3.2.18
+django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -70,7 +70,7 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-djangorestframework==3.12.4
+djangorestframework==3.14.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -88,7 +88,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.4.0
+faker==18.10.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -104,7 +104,7 @@ imagesize==1.4.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-importlib-metadata==6.3.0
+importlib-metadata==6.6.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -131,7 +131,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/test.txt
     #   astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -140,7 +140,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -152,7 +152,7 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.2.0
+platformdirs==3.5.3
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -167,12 +167,12 @@ pockets==0.9.1
     #   sphinxcontrib-napoleon
 pycodestyle==2.10.0
     # via -r requirements/test.txt
-pygments==2.15.0
+pygments==2.15.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-pylint==2.17.2
+pylint==2.17.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -187,17 +187,17 @@ pylint-django==2.5.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.2
     # via
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pytest==7.3.0
+pytest==7.3.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -217,11 +217,12 @@ pytz==2023.3
     #   -r requirements/test.txt
     #   babel
     #   django
+    #   djangorestframework
 pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-requests==2.28.2
+requests==2.31.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -246,7 +247,7 @@ sphinx==5.3.0
     #   -r requirements/test.txt
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
-sphinx-rtd-theme==1.2.0
+sphinx-rtd-theme==1.2.2
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -289,12 +290,12 @@ sphinxcontrib-serializinghtml==1.1.5
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -308,16 +309,18 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
+    #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   asgiref
     #   astroid
     #   pylint
-urllib3==1.26.15
+urllib3==2.0.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.13
     # via sphinx
 babel==2.12.1
     # via sphinx
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
@@ -20,21 +20,21 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.3.0
+importlib-metadata==6.6.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 packaging==23.1
     # via sphinx
 pockets==0.9.1
     # via sphinxcontrib-napoleon
-pygments==2.15.0
+pygments==2.15.1
     # via sphinx
 pytz==2023.3
     # via babel
-requests==2.28.2
+requests==2.31.0
     # via sphinx
 six==1.16.0
     # via
@@ -48,7 +48,7 @@ sphinx==5.3.0
     #   -r requirements/docs.in
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
-sphinx-rtd-theme==1.2.0
+sphinx-rtd-theme==1.2.2
     # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -66,7 +66,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.15
+urllib3==2.0.3
     # via requests
 zipp==3.15.0
     # via importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1.2
     # via -r requirements/pip.in
-setuptools==67.6.1
+setuptools==67.8.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,11 +8,11 @@ alabaster==0.7.13
     # via
     #   -r requirements/docs.txt
     #   sphinx
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.2
+astroid==2.15.5
     # via
     #   pylint
     #   pylint-celery
@@ -20,7 +20,7 @@ babel==2.12.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -r requirements/docs.txt
     #   requests
@@ -37,7 +37,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.3
+coverage[toml]==7.2.7
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
@@ -63,7 +63,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.4.0
+faker==18.10.1
     # via factory-boy
 freezegun==1.2.2
     # via -r requirements/test.in
@@ -75,7 +75,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==6.3.0
+importlib-metadata==6.6.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -94,13 +94,13 @@ jsonfield==3.1.0
     # via -r requirements/base.txt
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/docs.txt
     #   jinja2
 mccabe==0.7.0
     # via pylint
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.in
 packaging==23.1
     # via
@@ -109,7 +109,7 @@ packaging==23.1
     #   sphinx
 pbr==5.11.1
     # via stevedore
-platformdirs==3.2.0
+platformdirs==3.5.3
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -119,11 +119,11 @@ pockets==0.9.1
     #   sphinxcontrib-napoleon
 pycodestyle==2.10.0
     # via -r requirements/test.in
-pygments==2.15.0
+pygments==2.15.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-pylint==2.17.2
+pylint==2.17.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -133,15 +133,15 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.3.0
+pytest==7.3.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -158,9 +158,10 @@ pytz==2023.3
     #   -r requirements/docs.txt
     #   babel
     #   django
+    #   djangorestframework
 pyyaml==6.0
     # via code-annotations
-requests==2.28.2
+requests==2.31.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -181,7 +182,7 @@ sphinx==5.3.0
     #   -r requirements/docs.txt
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
-sphinx-rtd-theme==1.2.0
+sphinx-rtd-theme==1.2.2
     # via -r requirements/docs.txt
 sphinxcontrib-applehelp==1.0.4
     # via
@@ -213,11 +214,11 @@ sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
@@ -226,13 +227,15 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
+    #   -r requirements/base.txt
+    #   asgiref
     #   astroid
     #   pylint
-urllib3==1.26.15
+urllib3==2.0.3
     # via
     #   -r requirements/docs.txt
     #   requests

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,13 +6,13 @@
 #
 distlib==0.3.6
     # via virtualenv
-filelock==3.11.0
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.2.0
+platformdirs==3.5.3
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -26,5 +26,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/tox.in
-virtualenv==20.21.0
+virtualenv==20.23.0
     # via tox

--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.5.5'
+__version__ = '3.5.6'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32,40}-drf{312, latest}, quality, docs
+envlist = py38-django{32,40}-drf{312, drf314, latest}, quality, docs
 
 [testenv]
 setenv = 
@@ -9,6 +9,7 @@ deps =
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     drf312: djangorestframework<3.13.0
+    drf314: djangorestframework<3.15.0
     drflatest: djangorestframework
 commands = 
     python -Wd -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32,40}-drf{312, drf314, latest}, quality, docs
+envlist = py38-django{32,40}-drf{312, drf314}, quality, docs
 
 [testenv]
 setenv = 
@@ -10,8 +10,7 @@ deps =
     django40: Django>=4.0,<4.1
     drf312: djangorestframework<3.13.0
     drf314: djangorestframework<3.15.0
-    drflatest: djangorestframework
-commands = 
+commands =
     python -Wd -m pytest {posargs}
 
 [testenv:quality]


### PR DESCRIPTION
https://github.com/openedx/edx-platform/issues/32478

Bump the djangorestframework to latest one. To run tests with django4.0+ need this version

https://www.django-rest-framework.org/community/release-notes/?q=parse_header#314x-series
https://www.django-rest-framework.org/community/release-notes/?q=parse_header#3130