### PR TITLE
feanil/update rtd docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required: the version of this file's schema.
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: true
+
+# Set the version of python needed to build these docs.
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
+# Optionally install extra requirements required to build your docs
+python:
+  install:
+  - requirements: requirements/docs.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,12 +14,14 @@
 
 import os
 import sys
+import django
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../..'))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+django.setup()
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -260,3 +260,41 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+html_theme_options = {
+
+    "repository_url": 'https://github.com/openedx/edx-submissions',
+    "repository_branch": 'master',
+    "path_to_docs": "docs/",
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+    "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png">
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >Axim Collaborative</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
+
+# Note the logo won't show up properly yet because there is an upstream
+# bug in the theme that needs to be fixed first.
+# If you'd like you can temporarily copy the logo file to your `_static`
+# directory.
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.7.2
     # via django
-django==3.2.19
+django==3.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -26,5 +26,5 @@ pytz==2023.3
     #   djangorestframework
 sqlparse==0.4.4
     # via django
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via asgiref

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
 coverage==6.5.0
     # via coveralls
 coveralls==3.3.1
     # via -r requirements/ci.in
-distlib==0.3.6
+distlib==0.3.7
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -29,11 +29,11 @@ packaging==23.1
     # via
     #   -r requirements/tox.txt
     #   tox
-platformdirs==3.5.3
+platformdirs==3.10.0
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -55,9 +55,9 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/tox.txt
-urllib3==2.0.3
+urllib3==2.0.4
     # via requests
-virtualenv==20.23.0
+virtualenv==20.24.2
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,11 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   pydata-sphinx-theme
 alabaster==0.7.13
     # via
     #   -r requirements/docs.txt
@@ -12,9 +17,10 @@ alabaster==0.7.13
 asgiref==3.7.2
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.15.5
+astroid==2.15.6
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -23,18 +29,24 @@ babel==2.12.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   sphinx
-certifi==2023.5.7
+beautifulsoup4==4.12.2
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   pydata-sphinx-theme
+certifi==2023.7.22
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -44,7 +56,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==1.3.0
+code-annotations==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -54,14 +66,15 @@ coverage[toml]==7.2.7
     #   pytest-cov
 ddt==1.6.0
     # via -r requirements/test.txt
-dill==0.3.6
+dill==0.3.7
     # via
     #   -r requirements/test.txt
     #   pylint
-django==3.2.19
+django==3.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django-model-utils
     #   djangorestframework
@@ -69,26 +82,28 @@ django==3.2.19
 django-model-utils==4.3.1
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
 djangorestframework==3.14.0
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
-docutils==0.18.1
+docutils==0.19
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   sphinx
-    #   sphinx-rtd-theme
 edx-lint==5.3.4
     # via -r requirements/test.txt
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via
     #   -r requirements/test.txt
     #   pytest
-factory-boy==3.2.1
+factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==18.10.1
+faker==19.3.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -104,7 +119,7 @@ imagesize==1.4.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -126,6 +141,7 @@ jinja2==3.1.2
 jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
 lazy-object-proxy==1.9.0
     # via
@@ -140,23 +156,24 @@ mccabe==0.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
-mock==5.0.2
+mock==5.1.0
     # via -r requirements/test.txt
 packaging==23.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
 pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.5.3
+platformdirs==3.10.0
     # via
     #   -r requirements/test.txt
     #   pylint
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -165,14 +182,21 @@ pockets==0.9.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinxcontrib-napoleon
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via -r requirements/test.txt
-pygments==2.15.1
+pydata-sphinx-theme==0.13.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
+    #   sphinx-book-theme
+pygments==2.16.1
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   accessible-pygments
+    #   pydata-sphinx-theme
     #   sphinx
-pylint==2.17.4
+pylint==2.17.5
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -192,7 +216,7 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pytest==7.3.2
+pytest==7.4.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -218,7 +242,7 @@ pytz==2023.3
     #   babel
     #   django
     #   djangorestframework
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -240,14 +264,18 @@ snowballstemmer==2.2.0
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-sphinx==5.3.0
+soupsieve==2.4.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
-    #   sphinx-rtd-theme
-    #   sphinxcontrib-jquery
-sphinx-rtd-theme==1.2.2
+    #   beautifulsoup4
+sphinx==6.2.1
+    # via
+    #   -r requirements/docs.txt
+    #   -r requirements/test.txt
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -266,11 +294,6 @@ sphinxcontrib-htmlhelp==2.0.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-sphinxcontrib-jquery==4.1
-    # via
-    #   -r requirements/docs.txt
-    #   -r requirements/test.txt
-    #   sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via
     #   -r requirements/docs.txt
@@ -293,6 +316,7 @@ sphinxcontrib-serializinghtml==1.1.5
 sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django
 stevedore==5.1.0
@@ -309,18 +333,21 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.8
+tomlkit==0.12.1
     # via
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   asgiref
     #   astroid
+    #   faker
+    #   pydata-sphinx-theme
     #   pylint
-urllib3==2.0.3
+urllib3==2.0.4
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -329,7 +356,7 @@ wrapt==1.15.0
     # via
     #   -r requirements/test.txt
     #   astroid
-zipp==3.15.0
+zipp==3.16.2
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -2,5 +2,5 @@
 -c constraints.txt
 
 Sphinx
-sphinx-rtd-theme
+sphinx-book-theme
 sphinxcontrib-napoleon

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,6 +1,7 @@
 # Requirements for docs
 -c constraints.txt
 
+-r base.txt
 Sphinx
 sphinx-book-theme
 sphinxcontrib-napoleon

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,36 +4,70 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
-babel==2.12.1
-    # via sphinx
-certifi==2023.5.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-docutils==0.18.1
+asgiref==3.7.2
     # via
+    #   -r requirements/base.txt
+    #   django
+babel==2.12.1
+    # via
+    #   pydata-sphinx-theme
     #   sphinx
-    #   sphinx-rtd-theme
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
+certifi==2023.7.22
+    # via requests
+charset-normalizer==3.2.0
+    # via requests
+django==3.2.20
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/base.txt
+    #   django-model-utils
+    #   djangorestframework
+    #   jsonfield
+django-model-utils==4.3.1
+    # via -r requirements/base.txt
+djangorestframework==3.14.0
+    # via -r requirements/base.txt
+docutils==0.19
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
+jsonfield==3.1.0
+    # via -r requirements/base.txt
 markupsafe==2.1.3
     # via jinja2
 packaging==23.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 pockets==0.9.1
     # via sphinxcontrib-napoleon
-pygments==2.15.1
-    # via sphinx
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
+pygments==2.16.1
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 pytz==2023.3
-    # via babel
+    # via
+    #   -r requirements/base.txt
+    #   babel
+    #   django
+    #   djangorestframework
 requests==2.31.0
     # via sphinx
 six==1.16.0
@@ -42,13 +76,14 @@ six==1.16.0
     #   sphinxcontrib-napoleon
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.3.0
+soupsieve==2.4.1
+    # via beautifulsoup4
+sphinx==6.2.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/docs.in
-    #   sphinx-rtd-theme
-    #   sphinxcontrib-jquery
-sphinx-rtd-theme==1.2.2
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
     # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -56,8 +91,6 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
-sphinxcontrib-jquery==4.1
-    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-napoleon==0.7
@@ -66,7 +99,16 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==2.0.3
+sqlparse==0.4.4
+    # via
+    #   -r requirements/base.txt
+    #   django
+typing-extensions==4.7.1
+    # via
+    #   -r requirements/base.txt
+    #   asgiref
+    #   pydata-sphinx-theme
+urllib3==2.0.4
     # via requests
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,17 +6,20 @@
 #
 build==0.10.0
     # via pip-tools
-click==8.1.3
+click==8.1.6
     # via pip-tools
 packaging==23.1
     # via build
-pip-tools==6.13.0
+pip-tools==7.2.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
-    # via build
-wheel==0.40.0
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
+wheel==0.41.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.40.0
+wheel==0.41.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.1.2
+pip==23.2.1
     # via -r requirements/pip.in
-setuptools==67.8.0
+setuptools==68.0.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via
+    #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
 alabaster==0.7.13
     # via
     #   -r requirements/docs.txt
@@ -11,59 +15,70 @@ alabaster==0.7.13
 asgiref==3.7.2
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   django
-astroid==2.15.5
+astroid==2.15.6
     # via
     #   pylint
     #   pylint-celery
 babel==2.12.1
     # via
     #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
     #   sphinx
-certifi==2023.5.7
+beautifulsoup4==4.12.2
+    # via
+    #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
+certifi==2023.7.22
     # via
     #   -r requirements/docs.txt
     #   requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -r requirements/docs.txt
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   click-log
     #   code-annotations
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.3.0
+code-annotations==1.5.0
     # via edx-lint
 coverage[toml]==7.2.7
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
-dill==0.3.6
+dill==0.3.7
     # via pylint
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   django-model-utils
     #   djangorestframework
     #   jsonfield
 django-model-utils==4.3.1
-    # via -r requirements/base.txt
-    # via -r requirements/base.txt
-docutils==0.18.1
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/docs.txt
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/docs.txt
+docutils==0.19
     # via
     #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
     #   sphinx
-    #   sphinx-rtd-theme
 edx-lint==5.3.4
     # via -r requirements/test.in
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
-factory-boy==3.2.1
+factory-boy==3.3.0
     # via -r requirements/test.in
-faker==18.10.1
+faker==19.3.0
     # via factory-boy
 freezegun==1.2.2
     # via -r requirements/test.in
@@ -75,7 +90,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -91,7 +106,9 @@ jinja2==3.1.2
     #   code-annotations
     #   sphinx
 jsonfield==3.1.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/docs.txt
 lazy-object-proxy==1.9.0
     # via astroid
 markupsafe==2.1.3
@@ -100,30 +117,37 @@ markupsafe==2.1.3
     #   jinja2
 mccabe==0.7.0
     # via pylint
-mock==5.0.2
+mock==5.1.0
     # via -r requirements/test.in
 packaging==23.1
     # via
     #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
 pbr==5.11.1
     # via stevedore
-platformdirs==3.5.3
+platformdirs==3.10.0
     # via pylint
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pockets==0.9.1
     # via
     #   -r requirements/docs.txt
     #   sphinxcontrib-napoleon
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via -r requirements/test.in
-pygments==2.15.1
+pydata-sphinx-theme==0.13.3
     # via
     #   -r requirements/docs.txt
+    #   sphinx-book-theme
+pygments==2.16.1
+    # via
+    #   -r requirements/docs.txt
+    #   accessible-pygments
+    #   pydata-sphinx-theme
     #   sphinx
-pylint==2.17.4
+pylint==2.17.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -137,7 +161,7 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.3.2
+pytest==7.4.0
     # via
     #   pytest-cov
     #   pytest-django
@@ -159,7 +183,7 @@ pytz==2023.3
     #   babel
     #   django
     #   djangorestframework
-pyyaml==6.0
+pyyaml==6.0.1
     # via code-annotations
 requests==2.31.0
     # via
@@ -176,13 +200,16 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sphinx==5.3.0
+soupsieve==2.4.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/docs.txt
-    #   sphinx-rtd-theme
-    #   sphinxcontrib-jquery
-sphinx-rtd-theme==1.2.2
+    #   beautifulsoup4
+sphinx==6.2.1
+    # via
+    #   -r requirements/docs.txt
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
     # via -r requirements/docs.txt
 sphinxcontrib-applehelp==1.0.4
     # via
@@ -196,10 +223,6 @@ sphinxcontrib-htmlhelp==2.0.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sphinxcontrib-jquery==4.1
-    # via
-    #   -r requirements/docs.txt
-    #   sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via
     #   -r requirements/docs.txt
@@ -217,6 +240,7 @@ sphinxcontrib-serializinghtml==1.1.5
 sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   django
 stevedore==5.1.0
     # via code-annotations
@@ -227,21 +251,24 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.8
+tomlkit==0.12.1
     # via pylint
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via
     #   -r requirements/base.txt
+    #   -r requirements/docs.txt
     #   asgiref
     #   astroid
+    #   faker
+    #   pydata-sphinx-theme
     #   pylint
-urllib3==2.0.3
+urllib3==2.0.4
     # via
     #   -r requirements/docs.txt
     #   requests
 wrapt==1.15.0
     # via astroid
-zipp==3.15.0
+zipp==3.16.2
     # via
     #   -r requirements/docs.txt
     #   importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
 filelock==3.12.2
     # via
@@ -12,9 +12,9 @@ filelock==3.12.2
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.5.3
+platformdirs==3.10.0
     # via virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via tox
 py==1.11.0
     # via tox
@@ -26,5 +26,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/tox.in
-virtualenv==20.23.0
+virtualenv==20.24.2
     # via tox

--- a/submissions/api.py
+++ b/submissions/api.py
@@ -426,7 +426,8 @@ def get_all_submissions(course_id, item_id, item_type, read_replica=True):
 
 
 def get_all_course_submission_information(course_id, item_type, read_replica=True):
-    """ For the given course, get all student items of the given item type, all the submissions for those itemes,
+    """
+    For the given course, get all student items of the given item type, all the submissions for those itemes,
     and the latest scores for each item. If a submission was given a score that is not the latest score for the
     relevant student item, it will still be included but without score.
 
@@ -437,6 +438,7 @@ def get_all_course_submission_information(course_id, item_type, read_replica=Tru
 
     Yields:
         A tuple of three dictionaries representing:
+
         (1) a student item with the following fields:
             student_id
             course_id
@@ -485,7 +487,8 @@ def get_all_course_submission_information(course_id, item_type, read_replica=Tru
 
 
 def get_top_submissions(course_id, item_id, item_type, number_of_top_scores, use_cache=True, read_replica=True):
-    """Get a number of top scores for an assessment based on a particular student item
+    """
+    Get a number of top scores for an assessment based on a particular student item
 
     This function will return top scores for the piece of assessment.
     It will consider only the latest and greater than 0 score for a piece of assessment.
@@ -506,7 +509,7 @@ def get_top_submissions(course_id, item_id, item_type, number_of_top_scores, use
     Kwargs:
         use_cache (bool): If true, check the cache before retrieving querying the database.
         read_replica (bool): If true, attempt to use the read replica database.
-            If no read replica is available, use the default database.
+        If no read replica is available, use the default database.
 
     Returns:
         topscores (dict): The top scores for the assessment for the student item.
@@ -806,7 +809,8 @@ def reset_score(student_id, course_id, item_id, clear_state=False, emit_signal=T
 
 def set_score(submission_uuid, points_earned, points_possible,
               annotation_creator=None, annotation_type=None, annotation_reason=None):
-    """Set a score for a particular submission.
+    """
+    Set a score for a particular submission.
 
     Sets the score for a particular submission. This score is calculated
     externally to the API.
@@ -817,8 +821,8 @@ def set_score(submission_uuid, points_earned, points_possible,
         points_possible (int): The total points possible for this particular student item.
 
         annotation_creator (str): An optional field for recording who gave this particular score
-        annotation_type (str): An optional field for recording what type of annotation should be created,
-                                e.g. "staff_override".
+        annotation_type (str): An optional field for recording what type of
+        annotation should be created, e.g. "staff_override".
         annotation_reason (str): An optional field for recording why this score was set to its value.
 
     Returns:


### PR DESCRIPTION
This repo has a ReadTheDocs project that is currently broken, in making fixes for an upcoming RTD config deprecation, I noticed there were other issues with this repo.  Rather than dropping this from RTD, I'm fixing forward so that this repo has docs that are in compliance with our latest standards and that will not have issues with the RTD config deprecation late next month.


- docs: Add a ReadTheDocs config.
- docs: Move to the new sphinx book theme.
- docs: Update to be able to pull in docstrings.
- docs: Update docstrings to not throw warnings.
- chore: Run `make upgrade`
