### PR TITLE
fix: replaced deprecated github actions

### DIFF
--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache-dir
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache pip dependencies
       id: cache-dependencies


### PR DESCRIPTION
## Description
- `set-output` has been deprecated by GitHub and it is suggested to be replaced by GitHub.