### PR TITLE
build: adds ubuntu-24.04

### DIFF
--- a/.github/workflows/check-reserved-keywords.yml
+++ b/.github/workflows/check-reserved-keywords.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check-reserved-keywords:
     name: Check Reserved Keywords
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/check-reserved-keywords.yml
+++ b/.github/workflows/check-reserved-keywords.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check-reserved-keywords:
     name: Check Reserved Keywords
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-24.04]
         python-version: ['3.8', '3.11', '3.12']
         toxenv: [quality, docs, django42-drf315, django42-drflatest]
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-24.04]
+        os: [ ubuntu-20.04, ubuntu-latest ]
         python-version: ['3.8', '3.11', '3.12']
         toxenv: [quality, docs, django42-drf315, django42-drflatest]
   

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-24.04 ]
+        os: [ ubuntu-20.04, ubuntu-latest ]
         python-version: [ 3.8 ]
 
     steps:

--- a/.github/workflows/migrations-check.yml
+++ b/.github/workflows/migrations-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-20.04, ubuntu-24.04 ]
         python-version: [ 3.8 ]
 
     steps:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export BROWSER_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 .PHONY: clean, coverage, diff_cover, docs, help, dev_requirements, test, test_quality, test_requirements, upgrade,\
-		check_keywords
+		compile-requirements check_keywords
 
 help: ## Display this help message
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -51,23 +51,26 @@ $(COMMON_CONSTRAINTS_TXT):
 	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
 	echo "$(COMMON_CONSTRAINTS_TEMP_COMMENT)" | cat - $(@) > temp && mv temp $(@)
 
-export CUSTOM_COMPILE_COMMAND = make upgrade
-upgrade: piptools $(COMMON_CONSTRAINTS_TXT)	## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+compile-requirements: export CUSTOM_COMPILE_COMMAND = make upgrade
+compile-requirements: piptools $(COMMON_CONSTRAINTS_TXT)	## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	# Make sure to compile files after any other files they include!
-	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
-	pip-compile --upgrade --verbose --rebuild -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip-compile ${COMPILE_OPTS} --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile ${COMPILE_OPTS} --verbose --rebuild -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt
-	pip-compile --upgrade --verbose --rebuild -o requirements/base.txt requirements/base.in
-	pip-compile --upgrade --verbose --rebuild -o requirements/docs.txt requirements/docs.in
-	pip-compile --upgrade --verbose --rebuild -o requirements/test.txt requirements/test.in
-	pip-compile --upgrade --verbose --rebuild -o requirements/dev.txt requirements/dev.in
-	pip-compile --upgrade --verbose --rebuild -o requirements/tox.txt requirements/tox.in
-	pip-compile --upgrade --verbose --rebuild -o requirements/ci.txt requirements/ci.in
+	pip-compile ${COMPILE_OPTS} --verbose --rebuild -o requirements/base.txt requirements/base.in
+	pip-compile ${COMPILE_OPTS} --verbose --rebuild -o requirements/docs.txt requirements/docs.in
+	pip-compile ${COMPILE_OPTS} --verbose --rebuild -o requirements/test.txt requirements/test.in
+	pip-compile ${COMPILE_OPTS} --verbose --rebuild -o requirements/dev.txt requirements/dev.in
+	pip-compile ${COMPILE_OPTS} --verbose --rebuild -o requirements/tox.txt requirements/tox.in
+	pip-compile ${COMPILE_OPTS} --verbose --rebuild -o requirements/ci.txt requirements/ci.in
 	# Let tox control the Django and DRF versions for tests
 	sed -i.tmp '/^django==/d' requirements/test.txt
 	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
 	rm requirements/test.txt.tmp
+
+upgrade:  ## update the pip requirements files to use the latest releases satisfying our constraints
+	$(MAKE) compile-requirements COMPILE_OPTS="--upgrade"
 
 test: clean ## Run tests in the current virtualenv
 	pytest

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.4.0
+cachetools==5.5.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -35,7 +35,7 @@ filelock==3.15.4
     #   -r requirements/tox.txt
     #   tox
     #   virtualenv
-idna==3.7
+idna==3.8
     # via requests
 packaging==24.1
     # via
@@ -63,7 +63,7 @@ tomli==2.0.1
     #   coverage
     #   pyproject-api
     #   tox
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/tox.txt
 urllib3==2.2.2
     # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,7 @@
 -c common_constraints.txt
 
 backports.zoneinfo;python_version<"3.9"
+
+# Temporary until we drop support for python 3.8
+# Upgrading causes quality error: AttributeError: module 'importlib.resources' has no attribute 'files'
+edx-lint<5.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -109,8 +109,10 @@ edx-django-release-util==1.4.0
     #   -r requirements/base.txt
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
-edx-lint==5.4.0
-    # via -r requirements/test.txt
+edx-lint==5.3.7
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 exceptiongroup==1.2.2
     # via
     #   -r requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -109,21 +109,21 @@ edx-django-release-util==1.4.0
     #   -r requirements/base.txt
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
-edx-lint==5.3.7
+edx-lint==5.4.0
     # via -r requirements/test.txt
 exceptiongroup==1.2.2
     # via
     #   -r requirements/test.txt
     #   pytest
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.txt
-faker==26.3.0
+faker==28.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
 freezegun==1.5.1
     # via -r requirements/test.txt
-idna==3.7
+idna==3.8
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -133,7 +133,7 @@ imagesize==1.4.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -277,7 +277,7 @@ snowballstemmer==2.2.0
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -332,7 +332,7 @@ sqlparse==0.5.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -346,7 +346,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -46,11 +46,11 @@ docutils==0.19
     #   sphinx
 edx-django-release-util==1.4.0
     # via -r requirements/base.txt
-idna==3.7
+idna==3.8
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via sphinx
 jinja2==3.1.4
     # via sphinx
@@ -89,7 +89,7 @@ six==1.16.0
     #   sphinxcontrib-napoleon
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 sphinx==6.2.1
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==1.2.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via build
 packaging==24.1
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.44.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via -r requirements/pip.in
-setuptools==72.1.0
+setuptools==73.0.1
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -84,8 +84,10 @@ edx-django-release-util==1.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/docs.txt
-edx-lint==5.4.0
-    # via -r requirements/test.in
+edx-lint==5.3.7
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
 exceptiongroup==1.2.2
     # via pytest
 factory-boy==3.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -84,17 +84,17 @@ edx-django-release-util==1.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/docs.txt
-edx-lint==5.3.7
+edx-lint==5.4.0
     # via -r requirements/test.in
 exceptiongroup==1.2.2
     # via pytest
-factory-boy==3.3.0
+factory-boy==3.3.1
     # via -r requirements/test.in
-faker==26.3.0
+faker==28.0.0
     # via factory-boy
 freezegun==1.5.1
     # via -r requirements/test.in
-idna==3.7
+idna==3.8
     # via
     #   -r requirements/docs.txt
     #   requests
@@ -102,7 +102,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -214,7 +214,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via
     #   -r requirements/docs.txt
     #   beautifulsoup4
@@ -256,7 +256,7 @@ sqlparse==0.5.1
     #   -r requirements/base.txt
     #   -r requirements/docs.txt
     #   django
-stevedore==5.2.0
+stevedore==5.3.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
@@ -265,7 +265,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
     # via

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.4.0
+cachetools==5.5.0
     # via tox
 chardet==5.2.0
     # via tox
@@ -32,7 +32,7 @@ tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/tox.in
 virtualenv==20.26.3
     # via tox

--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.7.8'
+__version__ = '3.7.9'


### PR DESCRIPTION
## Description

Adds `ubuntu-24.04` to the list of OS used to run CI and migrations checks.

Where only one OS  `ubuntu-20.04` is configured, replaces it with ` `ubuntu-24.04`.

## Supporting Information

Closes https://github.com/openedx/edx-submissions/issues/259

## Testing

Tests passing here should be enough to merge this change, and a successful release to pypi will test the rest.