### PR TITLE
chore: support upgrading to django 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: ['3.11', '3.12']
-        toxenv: [quality, docs, django42-drf315, django42-drflatest]
+        toxenv: [quality, docs, django42-drf315, django42-drflatest, django52-drf315, django52-drflatest]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ setup(
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',

--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.9.0'
+__version__ = '3.10.0'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,312}-django{42}-drf{315,latest}, quality, docs
+envlist = py{311,312}-django{42,52}-drf{315,latest}, quality, docs
 
 [testenv]
 setenv = 
@@ -7,6 +7,7 @@ setenv =
 deps = 
     -r{toxinidir}/requirements/test.txt
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     drf315: djangorestframework<3.16
     drflatest: djangorestframework
 commands =


### PR DESCRIPTION
Support upgrading to django 5.2 while maintaining django 4.2 compatibility.

* ran django-upgrade (no changes)
* added django52 target to tox, CI, and setup docs
* bumps package version

### More Information

Closes: https://github.com/openedx/edx-submissions/issues/296
See https://discuss.openedx.org/t/django-5-2-upgrade-plan/15397